### PR TITLE
added mu initialization in non-magnetic region with LLG=TRUE

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,7 +39,7 @@ WarpxBinDir = Bin
 USE_PSATD = FALSE
 USE_PSATD_PICSAR = FALSE
 USE_RZ = FALSE
-USE_LLG = FALSE
+USE_LLG = TRUE
 
 WARPX_HOME := .
 include $(WARPX_HOME)/Source/Make.WarpX

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM.cpp
@@ -124,7 +124,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian(
                 amrex::Real mag_gamma_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrx != 0 && mag_alpha_arrx != 0 && mag_gamma_arrx != 0)
+                if (mag_Ms_arrx != 0._rt)
                 {
                     // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -145,7 +145,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian(
 
                     // magnetic material properties mag_alpha and mag_Ms are defined at faces
                     // removed the interpolation from version with cell-nodal material properties
-                    amrex::Real mag_gammaL = mag_gamma_arrx / (1.0 + std::pow(mag_alpha_arrx, 2.0));
+                    amrex::Real mag_gammaL = mag_gamma_arrx / (1._rt + std::pow(mag_alpha_arrx, 2.0));
 
                     // 0 = unsaturated; compute |M| locally.  1 = saturated; use M_s
                     amrex::Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_xface(i, j, k, 0), 2.0) + std::pow(M_xface(i, j, k, 1), 2.0) + std::pow(M_xface(i, j, k, 2), 2.0))
@@ -214,7 +214,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian(
                 Real mag_gamma_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arry != 0 && mag_alpha_arry != 0 && mag_gamma_arry != 0)
+                if (mag_Ms_arry != 0._rt)
                 {
                     // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -235,7 +235,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian(
 
                     // magnetic material properties mag_alpha and mag_Ms are defined at faces
                     // removed the interpolation from version with cell-nodal material properties
-                    Real mag_gammaL = mag_gamma_arry / (1.0 + std::pow(mag_alpha_arry, 2.0));
+                    Real mag_gammaL = mag_gamma_arry / (1._rt + std::pow(mag_alpha_arry, 2.0));
 
                     // 0 = unsaturated; compute |M| locally.  1 = saturated; use M_s
                     Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_yface(i, j, k, 0), 2.0) + std::pow(M_yface(i, j, k, 1), 2.0) + std::pow(M_yface(i, j, k, 2), 2.0))
@@ -303,7 +303,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian(
                 Real mag_gamma_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrz != 0 && mag_alpha_arrz != 0 && mag_gamma_arrz != 0)
+                if (mag_Ms_arrz != 0._rt)
                 {
                     // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -325,7 +325,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian(
 
                     // magnetic material properties mag_alpha and mag_Ms are defined at faces
                     // removed the interpolation from version with cell-nodal material properties
-                    Real mag_gammaL = mag_gamma_arrz / (1.0 + std::pow(mag_alpha_arrz, 2.0));
+                    Real mag_gammaL = mag_gamma_arrz / (1._rt + std::pow(mag_alpha_arrz, 2.0));
 
                     // 0 = unsaturated; compute |M| locally.  1 = saturated; use M_s
                     Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_zface(i, j, k, 0), 2.0_rt) + std::pow(M_zface(i, j, k, 1), 2.0_rt) + std::pow(M_zface(i, j, k, 2), 2.0_rt))
@@ -416,29 +416,58 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian(
         Box const &tby = mfi.tilebox(Hfield[1]->ixType().toIntVect());
         Box const &tbz = mfi.tilebox(Hfield[2]->ixType().toIntVect());
 
-        amrex::Real mu0_inv = 1. / PhysConst::mu0;
+        // read in Ms to decide if the grid is magnetic or not
+        auto& mag_Ms_mf = macroscopic_properties->getmag_Ms_mf();
+        Array4<Real> const& mag_Ms_arr = mag_Ms_mf.array(mfi);
+
+        // mu_mf will be imported but will only be called at grids where Ms == 0
+        auto& mu_mf = macroscopic_properties->getmu_mf();
+        Array4<Real> const& mu_arr = mu_mf.array(mfi);
+
+        amrex::Real const mu0_inv = 1. / PhysConst::mu0;
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(tbx, tby, tbz,
             [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                Hx(i, j, k) += mu0_inv * dt * T_Algo::UpwardDz(Ey, coefs_z, n_coefs_z, i, j, k)
-                             - mu0_inv * dt * T_Algo::UpwardDy(Ez, coefs_y, n_coefs_y, i, j, k);
-                if (coupling == 1) {
-                    Hx(i, j, k) += - M_xface(i, j, k, 0) + M_xface_old(i, j, k, 0);
+                Real mag_Ms_arrx = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(1,0,0), mag_Ms_arr);
+                if (mag_Ms_arrx == 0._rt){ // nonmagnetic region
+                    Real mu_arrx = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(1,0,0), mu_arr);
+                    Hx(i, j, k) += 1. / mu_arrx * dt * T_Algo::UpwardDz(Ey, coefs_z, n_coefs_z, i, j, k)
+                                 - 1. / mu_arrx * dt * T_Algo::UpwardDy(Ez, coefs_y, n_coefs_y, i, j, k);
+                } else if (mag_Ms_arrx > 0){ // magnetic region
+                    Hx(i, j, k) += mu0_inv * dt * T_Algo::UpwardDz(Ey, coefs_z, n_coefs_z, i, j, k)
+                                 - mu0_inv * dt * T_Algo::UpwardDy(Ez, coefs_y, n_coefs_y, i, j, k);
+                    if (coupling == 1) {
+                        Hx(i, j, k) += - M_xface(i, j, k, 0) + M_xface_old(i, j, k, 0);
+                    }
                 }
             },
             [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                Hy(i, j, k) += mu0_inv * dt * T_Algo::UpwardDx(Ez, coefs_x, n_coefs_x, i, j, k)
-                             - mu0_inv * dt * T_Algo::UpwardDz(Ex, coefs_z, n_coefs_z, i, j, k);
-                if (coupling == 1) {
-                    Hy(i, j, k) +=  - M_yface(i, j, k, 1) + M_yface_old(i, j, k, 1);
+                Real mag_Ms_arry = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,1,0), mag_Ms_arr);
+                if (mag_Ms_arry == 0._rt){ // nonmagnetic region
+                    Real mu_arry = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,1,0), mu_arr);
+                    Hy(i, j, k) += 1. / mu_arry * dt * T_Algo::UpwardDx(Ez, coefs_x, n_coefs_x, i, j, k)
+                                 - 1. / mu_arry * dt * T_Algo::UpwardDz(Ex, coefs_z, n_coefs_z, i, j, k);
+                } else if (mag_Ms_arry > 0){ // magnetic region
+                    Hy(i, j, k) += mu0_inv * dt * T_Algo::UpwardDx(Ez, coefs_x, n_coefs_x, i, j, k)
+                                 - mu0_inv * dt * T_Algo::UpwardDz(Ex, coefs_z, n_coefs_z, i, j, k);
+                    if (coupling == 1){
+                        Hy(i, j, k) += - M_yface(i, j, k, 1) + M_yface_old(i, j, k, 1);
+                    }
                 }
             },
             [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                Hz(i, j, k) += mu0_inv * dt * T_Algo::UpwardDy(Ex, coefs_y, n_coefs_y, i, j, k)
-                             - mu0_inv * dt * T_Algo::UpwardDx(Ey, coefs_x, n_coefs_x, i, j, k);
-                if (coupling == 1) {
-                    Hz(i, j, k) += - M_zface(i, j, k, 2) + M_zface_old(i, j, k, 2);
+                Real mag_Ms_arrz = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,0,1), mag_Ms_arr);
+                if (mag_Ms_arrz == 0._rt){ // nonmagnetic region
+                    Real mu_arrz = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,0,1), mu_arr);
+                    Hz(i, j, k) += 1. / mu_arrz * dt * T_Algo::UpwardDy(Ex, coefs_y, n_coefs_y, i, j, k)
+                                 - 1. / mu_arrz * dt * T_Algo::UpwardDx(Ey, coefs_x, n_coefs_x, i, j, k);
+                } else if (mag_Ms_arrz > 0){ // magnetic region
+                    Hz(i, j, k) += mu0_inv * dt * T_Algo::UpwardDy(Ex, coefs_y, n_coefs_y, i, j, k)
+                                 - mu0_inv * dt * T_Algo::UpwardDx(Ey, coefs_x, n_coefs_x, i, j, k);
+                    if (coupling == 1){
+                        Hz(i, j, k) += - M_zface(i, j, k, 2) + M_zface_old(i, j, k, 2);
+                    }
                 }
             });
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM.cpp
@@ -499,19 +499,45 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian(
         Box const &tby = mfi.tilebox(Bfield[1]->ixType().toIntVect());
         Box const &tbz = mfi.tilebox(Bfield[2]->ixType().toIntVect());
 
+        // read in Ms to decide if the grid is magnetic or not
+        auto& mag_Ms_mf = macroscopic_properties->getmag_Ms_mf();
+        Array4<Real> const& mag_Ms_arr = mag_Ms_mf.array(mfi);
+
+        // mu_mf will be imported but will only be called at grids where Ms == 0
+        auto& mu_mf = macroscopic_properties->getmu_mf();
+        Array4<Real> const& mu_arr = mu_mf.array(mfi);
+        
         // Loop over the cells and update the fields
         amrex::ParallelFor(tbx, tby, tbz,
 
             [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                Bx(i, j, k) = PhysConst::mu0 * (M_xface(i, j, k, 0) + Hx(i, j, k));
+                Real mag_Ms_arrx = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(1,0,0), mag_Ms_arr);
+                if (mag_Ms_arrx == 0._rt){ // nonmagnetic region
+                    Real mu_arrx = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(1,0,0), mu_arr);
+                    Bx(i, j, k) = mu_arrx * Hx(i, j, k);
+                } else if (mag_Ms_arrx > 0){
+                    Bx(i, j, k) = PhysConst::mu0 * (M_xface(i, j, k, 0) + Hx(i, j, k));
+                }
             },
 
             [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                By(i, j, k) = PhysConst::mu0 * (M_yface(i, j, k, 1) + Hy(i, j, k));
+                Real mag_Ms_arry = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,1,0), mag_Ms_arr);
+                if (mag_Ms_arry == 0._rt){ // nonmagnetic region
+                    Real mu_arry = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,1,0), mu_arr);
+                    By(i, j, k) =  mu_arry * Hy(i, j, k);
+                } else if (mag_Ms_arry > 0){
+                    By(i, j, k) = PhysConst::mu0 * (M_yface(i, j, k, 1) + Hy(i, j, k));
+                }
             },
 
             [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                Bz(i, j, k) = PhysConst::mu0 * (M_zface(i, j, k, 2) + Hz(i, j, k));
+                Real mag_Ms_arrz = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,0,1), mag_Ms_arr);
+                if (mag_Ms_arrz == 0._rt){ // nonmagnetic region
+                    Real mu_arrz = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,0,1), mu_arr);
+                    Bz(i, j, k) = mu_arrz * Hz(i, j, k);
+                } else if (mag_Ms_arrz > 0){
+                    Bz(i, j, k) = PhysConst::mu0 * (M_zface(i, j, k, 2) + Hz(i, j, k));
+                }
             });
     }
 }

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
@@ -132,7 +132,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                 Real mag_gamma_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrx != 0){
+                if (mag_Ms_arrx != 0.){
 
                     // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -186,7 +186,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                 Real mag_gamma_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arry != 0){
+                if (mag_Ms_arry != 0.){
 
                     // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -240,7 +240,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                 Real mag_gamma_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrz != 0){
+                if (mag_Ms_arrz != 0.){
 
                     // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -362,7 +362,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                     Real mag_gamma_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arrx != 0){
+                    if (mag_Ms_arrx != 0.){
                         // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
                         // Hy and Hz can be acquired by interpolation
 
@@ -450,7 +450,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                     Real mag_gamma_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arry != 0){
+                    if (mag_Ms_arry != 0.){
                         // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
                         // Hy and Hz can be acquired by interpolation
 
@@ -538,7 +538,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                     Real mag_gamma_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arrz != 0){
+                    if (mag_Ms_arrz != 0.){
                         // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
                         // Hy and Hz can be acquired by interpolation
 
@@ -667,7 +667,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                     Real mag_Ms_arrx = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(1,0,0), mag_Ms_arr);
-                    if (mag_Ms_arrx == 0){ // nonmagnetic region
+                    if (mag_Ms_arrx == 0.){ // nonmagnetic region
                         Real mu_arrx = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(1,0,0), mu_arr);
                         Hx(i, j, k) = Hx_old(i, j, k) + 1. / mu_arrx * dt * T_Algo::UpwardDz(Ey, coefs_z, n_coefs_z, i, j, k)
                                                       - 1. / mu_arrx * dt * T_Algo::UpwardDy(Ez, coefs_y, n_coefs_y, i, j, k);
@@ -682,7 +682,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                     Real mag_Ms_arry = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,1,0), mag_Ms_arr);
-                    if (mag_Ms_arry == 0){ // nonmagnetic region
+                    if (mag_Ms_arry == 0.){ // nonmagnetic region
                         Real mu_arry = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,1,0), mu_arr);
                         Hy(i, j, k) = Hy_old(i, j, k) + 1. / mu_arry * dt * T_Algo::UpwardDx(Ez, coefs_x, n_coefs_x, i, j, k)
                                                       - 1. / mu_arry * dt * T_Algo::UpwardDz(Ex, coefs_z, n_coefs_z, i, j, k);
@@ -697,7 +697,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                     Real mag_Ms_arrz = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,0,1), mag_Ms_arr);
-                    if (mag_Ms_arrz == 0){ // nonmagnetic region
+                    if (mag_Ms_arrz == 0.){ // nonmagnetic region
                         Real mu_arrz = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,0,1), mu_arr);
                         Hz(i, j, k) = Hz_old(i, j, k) + 1. / mu_arrz * dt * T_Algo::UpwardDy(Ex, coefs_y, n_coefs_y, i, j, k)
                                                       - 1. / mu_arrz * dt * T_Algo::UpwardDx(Ey, coefs_x, n_coefs_x, i, j, k);
@@ -752,7 +752,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                             Real mag_Ms_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_Ms_arr);
 
-                            if (mag_Ms_arrx != 0){
+                            if (mag_Ms_arrx != 0.){
                                 // temporary normalized magnitude of M_xface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                                 amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_xface(i, j, k, 0), 2.0) + std::pow(M_xface(i, j, k, 1), 2.0) +
@@ -776,7 +776,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                             Real mag_Ms_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_Ms_arr);
 
-                            if (mag_Ms_arry != 0){
+                            if (mag_Ms_arry != 0.){
                                 // temporary normalized magnitude of M_yface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                                 amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_yface(i, j, k, 0), 2.0) + std::pow(M_yface(i, j, k, 1), 2.0) +
@@ -800,7 +800,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                             Real mag_Ms_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_Ms_arr);
 
-                            if (mag_Ms_arrz != 0){
+                            if (mag_Ms_arrz != 0.){
                                 // temporary normalized magnitude of M_zface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                                 amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_zface(i, j, k, 0), 2.0_rt) + std::pow(M_zface(i, j, k, 1), 2.0_rt) +

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
@@ -132,7 +132,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                 Real mag_gamma_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrx != 0.){
+                if (mag_Ms_arrx != 0._rt){
 
                     // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -186,7 +186,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                 Real mag_gamma_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arry != 0.){
+                if (mag_Ms_arry != 0._rt){
 
                     // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -240,7 +240,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                 Real mag_gamma_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrz != 0.){
+                if (mag_Ms_arrz != 0._rt){
 
                     // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -362,7 +362,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                     Real mag_gamma_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arrx != 0.){
+                    if (mag_Ms_arrx != 0._rt){
                         // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
                         // Hy and Hz can be acquired by interpolation
 
@@ -450,7 +450,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                     Real mag_gamma_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arry != 0.){
+                    if (mag_Ms_arry != 0._rt){
                         // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
                         // Hy and Hz can be acquired by interpolation
 
@@ -538,7 +538,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
                     Real mag_gamma_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arrz != 0.){
+                    if (mag_Ms_arrz != 0._rt){
                         // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
                         // Hy and Hz can be acquired by interpolation
 
@@ -666,7 +666,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                     Real mag_Ms_arrx = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(1,0,0), mag_Ms_arr);
-                    if (mag_Ms_arrx == 0.){ // nonmagnetic region
+                    if (mag_Ms_arrx == 0._rt){ // nonmagnetic region
                         Real mu_arrx = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(1,0,0), mu_arr);
                         Hx(i, j, k) = Hx_old(i, j, k) + 1. / mu_arrx * dt * T_Algo::UpwardDz(Ey, coefs_z, n_coefs_z, i, j, k)
                                                       - 1. / mu_arrx * dt * T_Algo::UpwardDy(Ez, coefs_y, n_coefs_y, i, j, k);
@@ -681,7 +681,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                     Real mag_Ms_arry = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,1,0), mag_Ms_arr);
-                    if (mag_Ms_arry == 0.){ // nonmagnetic region
+                    if (mag_Ms_arry == 0._rt){ // nonmagnetic region
                         Real mu_arry = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,1,0), mu_arr);
                         Hy(i, j, k) = Hy_old(i, j, k) + 1. / mu_arry * dt * T_Algo::UpwardDx(Ez, coefs_x, n_coefs_x, i, j, k)
                                                       - 1. / mu_arry * dt * T_Algo::UpwardDz(Ex, coefs_z, n_coefs_z, i, j, k);
@@ -696,7 +696,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                 [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                     Real mag_Ms_arrz = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,0,1), mag_Ms_arr);
-                    if (mag_Ms_arrz == 0.){ // nonmagnetic region
+                    if (mag_Ms_arrz == 0._rt){ // nonmagnetic region
                         Real mu_arrz = MacroscopicProperties::macro_avg_to_face(i, j, k, amrex::IntVect(0,0,1), mu_arr);
                         Hz(i, j, k) = Hz_old(i, j, k) + 1. / mu_arrz * dt * T_Algo::UpwardDy(Ex, coefs_y, n_coefs_y, i, j, k)
                                                       - 1. / mu_arrz * dt * T_Algo::UpwardDx(Ey, coefs_x, n_coefs_x, i, j, k);
@@ -751,7 +751,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                             Real mag_Ms_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_Ms_arr);
 
-                            if (mag_Ms_arrx != 0.){
+                            if (mag_Ms_arrx != 0._rt){
                                 // temporary normalized magnitude of M_xface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                                 amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_xface(i, j, k, 0), 2.0) + std::pow(M_xface(i, j, k, 1), 2.0) +
@@ -775,7 +775,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                             Real mag_Ms_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_Ms_arr);
 
-                            if (mag_Ms_arry != 0.){
+                            if (mag_Ms_arry != 0._rt){
                                 // temporary normalized magnitude of M_yface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                                 amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_yface(i, j, k, 0), 2.0) + std::pow(M_yface(i, j, k, 1), 2.0) +
@@ -799,7 +799,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
 
                             Real mag_Ms_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_Ms_arr);
 
-                            if (mag_Ms_arrz != 0.){
+                            if (mag_Ms_arrz != 0._rt){
                                 // temporary normalized magnitude of M_zface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                                 amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_zface(i, j, k, 0), 2.0_rt) + std::pow(M_zface(i, j, k, 1), 2.0_rt) +

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
@@ -656,6 +656,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
             auto& mag_Ms_mf = macroscopic_properties->getmag_Ms_mf();
             Array4<Real> const& mag_Ms_arr = mag_Ms_mf.array(mfi);
 
+            // mu_mf will be imported but will only be called at grids where Ms == 0
             auto& mu_mf = macroscopic_properties->getmu_mf();
             Array4<Real> const& mu_arr = mu_mf.array(mfi);
 
@@ -713,7 +714,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
         }
 
         // Check the error between Mfield and Mfield_prev and decide whether another iteration is needed
-        amrex::Real M_iter_maxerror = -1.0;
+        amrex::Real M_iter_maxerror = -1._rt;
         for (int iface = 0; iface < 3; iface++){
             for (int jcomp = 0; jcomp < 3; jcomp++){
                 Real M_iter_error = Mfield_error[iface]->norm0(jcomp);

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveHM_2nd.cpp
@@ -655,10 +655,9 @@ void FiniteDifferenceSolver::MacroscopicEvolveHMCartesian_2nd(
             // read in Ms to decide if the grid is magnetic or not
             auto& mag_Ms_mf = macroscopic_properties->getmag_Ms_mf();
             Array4<Real> const& mag_Ms_arr = mag_Ms_mf.array(mfi);
-            //if (mag_Ms_mf.min(1,0) == 0){
-                auto& mu_mf = macroscopic_properties->getmu_mf();
-                Array4<Real> const& mu_arr = mu_mf.array(mfi);
-            //}
+
+            auto& mu_mf = macroscopic_properties->getmu_mf();
+            Array4<Real> const& mu_arr = mu_mf.array(mfi);
 
             amrex::Real const mu0_inv = 1. / PhysConst::mu0;
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM.cpp
@@ -105,7 +105,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian(
                 Real mag_gamma_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrx != 0 && mag_alpha_arrx != 0 && mag_gamma_arrx != 0)
+                if (mag_Ms_arrx != 0._rt)
                 {
                     // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -123,7 +123,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian(
                         Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0, 0, 1), amrex::IntVect(1, 0, 0), Bz, M_xface);
                     }
 
-                    Real mag_gamma = mag_gamma_arrx / (1.0 + std::pow(mag_alpha_arrx, 2.0));
+                    Real mag_gamma = mag_gamma_arrx / (1._rt + std::pow(mag_alpha_arrx, 2.0));
 
                     Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_xface(i, j, k, 0), 2.0) + std::pow(M_xface(i, j, k, 1), 2.0) + std::pow(M_xface(i, j, k, 2), 2.0)) : mag_Ms_arrx;
                     Real Gil_damp = PhysConst::mu0 * mag_gamma * mag_alpha_arrx / M_magnitude;
@@ -185,7 +185,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian(
                 Real mag_gamma_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arry != 0 && mag_alpha_arry != 0 && mag_gamma_arry != 0)
+                if (mag_Ms_arry != 0._rt)
                 {
                     // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -203,7 +203,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian(
                         Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0, 0, 1), amrex::IntVect(0, 1, 0), Bz, M_yface);
                     }
 
-                    Real mag_gamma = mag_gamma_arry / (1.0 + std::pow(mag_alpha_arry, 2.0));
+                    Real mag_gamma = mag_gamma_arry / (1._rt + std::pow(mag_alpha_arry, 2.0));
 
                     Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_yface(i, j, k, 0), 2.0) + std::pow(M_yface(i, j, k, 1), 2.0) + std::pow(M_yface(i, j, k, 2), 2.0)) : mag_Ms_arry;
                     Real Gil_damp = PhysConst::mu0 * mag_gamma * mag_alpha_arry / M_magnitude;
@@ -264,7 +264,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian(
                 Real mag_gamma_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrz != 0 && mag_alpha_arrz != 0 && mag_gamma_arrz != 0)
+                if (mag_Ms_arrz != 0._rt)
                 {
                     // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -283,7 +283,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian(
                         Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0, 0, 1), amrex::IntVect(0, 0, 1), Bz, M_zface);
                     }
 
-                    Real mag_gamma = mag_gamma_arrz / (1.0 + std::pow(mag_alpha_arrz, 2.0));
+                    Real mag_gamma = mag_gamma_arrz / (1._rt + std::pow(mag_alpha_arrz, 2.0));
 
                     Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_zface(i, j, k, 0), 2.0_rt) + std::pow(M_zface(i, j, k, 1), 2.0_rt) + std::pow(M_zface(i, j, k, 2), 2.0_rt)) : mag_Ms_arrz;
                     Real Gil_damp = PhysConst::mu0 * mag_gamma * mag_alpha_arrz / M_magnitude;

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM_2nd.cpp
@@ -125,7 +125,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
                 Real mag_gamma_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrx != 0 && mag_alpha_arrx != 0 && mag_gamma_arrx != 0)
+                if (mag_Ms_arrx != 0._rt)
                 {
                     // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -179,7 +179,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
                 Real mag_gamma_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arry != 0 && mag_alpha_arry != 0 && mag_gamma_arry != 0)
+                if (mag_Ms_arry != 0._rt)
                 {
                     // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -233,7 +233,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
                 Real mag_gamma_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_gamma_arr);
 
                 // determine if the material is nonmagnetic or not
-                if (mag_Ms_arrz != 0 && mag_alpha_arrz != 0 && mag_gamma_arrz != 0)
+                if (mag_Ms_arrz != 0._rt)
                 {
                     // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
                     // Hy and Hz can be acquired by interpolation
@@ -350,7 +350,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
                     Real mag_gamma_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arrx != 0 && mag_alpha_arrx != 0 && mag_gamma_arrx != 0)
+                    if (mag_Ms_arrx != 0._rt)
                     {
                         // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
                         // Hy and Hz can be acquired by interpolation
@@ -441,7 +441,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
                     Real mag_gamma_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arry != 0 && mag_alpha_arry != 0 && mag_gamma_arry != 0)
+                    if (mag_Ms_arry != 0._rt)
                     {
                         // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
                         // Hy and Hz can be acquired by interpolation
@@ -532,7 +532,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
                     Real mag_gamma_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_gamma_arr);
 
                     // determine if the material is nonmagnetic or not
-                    if (mag_Ms_arrz != 0 && mag_alpha_arrz != 0 && mag_gamma_arrz != 0)
+                    if (mag_Ms_arrz != 0._rt)
                     {
                         // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
                         // Hy and Hz can be acquired by interpolation
@@ -618,7 +618,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
         }
 
         // Check the error between Mfield and Mfield_prev and decide whether another iteration is needed
-        amrex::Real M_iter_maxerror = -1.0;
+        amrex::Real M_iter_maxerror = -1._rt;
         for (int i = 0; i < 1; i++) {
             for (int j = 0; j < 3; j++) {
                 Real M_iter_error = Mfield_error[i]->norm0(j);
@@ -657,7 +657,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
 
                             Real mag_Ms_arrx = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_Ms_arr);
 
-                            if (mag_Ms_arrx != 0)
+                            if (mag_Ms_arrx != 0._rt)
                             {
                                 // temporary normalized magnitude of M_xface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
@@ -683,7 +683,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
 
                             Real mag_Ms_arry = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_Ms_arr);
 
-                            if (mag_Ms_arry != 0)
+                            if (mag_Ms_arry != 0._rt)
                             {
                                 // temporary normalized magnitude of M_yface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
@@ -709,7 +709,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveMCartesian_2nd(
 
                             Real mag_Ms_arrz = MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_Ms_arr);
 
-                            if (mag_Ms_arrz != 0)
+                            if (mag_Ms_arrz != 0._rt)
                             {
                                 // temporary normalized magnitude of M_zface field at the fixed point
                                 // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -187,10 +187,10 @@ MacroscopicProperties::InitData ()
         InitializeMacroMultiFabUsingParser(m_mag_Ms_mf.get(), getParser(m_mag_Ms_parser), lev);
     }
     // if there are regions with Ms=0, the user must provide mur value there
-    if ((*m_mag_Ms_mf).min(1,0) < 0){
+    if ((*m_mag_Ms_mf).min(1,0) < 0.){
         amrex::Abort("Ms must be non-negative values");
     }
-    else if ((*m_mag_Ms_mf).min(1,0) == 0){
+    else if ((*m_mag_Ms_mf).min(1,0) == 0.){
         if (m_mu_s != "constant" && m_mu_s != "parse_mu_function"){
             amrex::Abort("permeability must be specified since part of the simulation domain is non-magnetic !");
         }
@@ -203,7 +203,7 @@ MacroscopicProperties::InitData ()
     else if (m_mag_alpha_s == "parse_mag_alpha_function"){
         InitializeMacroMultiFabUsingParser(m_mag_alpha_mf.get(), getParser(m_mag_alpha_parser), lev);
     }
-    if (m_mag_alpha_mf->min(0,m_mag_alpha_mf->nGrow()) < 0) {
+    if (m_mag_alpha_mf->min(0,m_mag_alpha_mf->nGrow()) < 0.) {
         amrex::Abort("alpha should be positive, but the user input has negative values");
     }
 
@@ -215,7 +215,7 @@ MacroscopicProperties::InitData ()
     else if (m_mag_gamma_s == "parse_mag_gamma_function"){
         InitializeMacroMultiFabUsingParser(m_mag_gamma_mf.get(), getParser(m_mag_gamma_parser), lev);
     }
-    if (m_mag_gamma_mf->max(0,m_mag_gamma_mf->nGrow()) > 0) {
+    if (m_mag_gamma_mf->max(0,m_mag_gamma_mf->nGrow()) > 0.) {
         amrex::Abort("gamma should be negative, but the user input has positive values");
     }
 #endif

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -58,7 +58,7 @@ MacroscopicProperties::ReadParameters ()
                                  makeParser(m_str_epsilon_function,{"x","y","z"}) ) );
     }
 
-    // Query input for material permittivity, epsilon.
+    // Query input for material permeability, mu
     bool mu_specified = false;
     if (pp.query("mu", m_mu)) {
         m_mu_s = "constant";
@@ -186,6 +186,15 @@ MacroscopicProperties::InitData ()
     else if (m_mag_Ms_s == "parse_mag_Ms_function"){
         InitializeMacroMultiFabUsingParser(m_mag_Ms_mf.get(), getParser(m_mag_Ms_parser), lev);
     }
+    // if there are regions with Ms=0, the user must provide mur value there
+    if ((*m_mag_Ms_mf).min(1,0) < 0){
+        amrex::Abort("Ms must be non-negative values");
+    }
+    else if ((*m_mag_Ms_mf).min(1,0) == 0){
+        if (m_mu_s != "constant" && m_mu_s != "parse_mu_function"){
+            amrex::Abort("permeability must be specified since part of the simulation domain is non-magnetic !");
+        }
+    }    
 
     // mag_alpha - defined at node
     if (m_mag_alpha_s == "constant") {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -481,15 +481,6 @@ public:
             amrex::Real const time);
 #endif
 
-/* for output */
-#ifdef WARPX_MAG_LLG
-        void MacroscopicfieldOutput (
-            std::array< std::unique_ptr<amrex::MultiFab>, 3 > & Mfield,
-            std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Efield,
-            std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Bfield,
-            amrex::Real const time);
-#endif
-
     /** \brief apply QED correction on electric field
      * \param dt vector of time steps (for all levels)
      */


### PR DESCRIPTION
Added features of calling macroscopic permeability `mu` in regions with zero `Ms`. 
Briefly, 
if in some regions, `Ms == 0`, the user must input the value of `mu`, which will be used to update `Hfield`. 

In the test case, the coupling between Maxwell equations and LLG equation is turned on, however, the value of `Ms` is set to be zero, we are expecting to see simulation results identical to the pure-Maxwell ones. And when `mu_r = 9`, the value of `B` should be approximately 9 times of that with `mu_r = 1`.

**Case 1**: `mu_r = 1`, LLG+Maxwell, coupling is turned on, `Ms = 0`
<img width="484" alt="image" src="https://user-images.githubusercontent.com/58234082/96818206-ff38f880-13ee-11eb-862a-64dfbb6b0cba.png">
<img width="486" alt="image" src="https://user-images.githubusercontent.com/58234082/96818242-18da4000-13ef-11eb-95aa-d736a0f29de1.png">
<img width="485" alt="image" src="https://user-images.githubusercontent.com/58234082/96818372-6656ad00-13ef-11eb-99a8-52db3b6deb26.png">
<img width="479" alt="image" src="https://user-images.githubusercontent.com/58234082/96818390-6d7dbb00-13ef-11eb-83ab-bda6dc567a9a.png">


**Case 2**: `mu_r = 9`, LLG+Maxwell, coupling is turned on, `Ms = 0`
<img width="478" alt="image" src="https://user-images.githubusercontent.com/58234082/97242118-57924080-17c9-11eb-8840-955a426c502e.png">
<img width="488" alt="image" src="https://user-images.githubusercontent.com/58234082/97242176-8a3c3900-17c9-11eb-8f40-cc005b9c0e36.png">
<img width="477" alt="image" src="https://user-images.githubusercontent.com/58234082/97242183-91634700-17c9-11eb-9c33-79ac639366b9.png">
<img width="480" alt="image" src="https://user-images.githubusercontent.com/58234082/97242189-97f1be80-17c9-11eb-806e-692963065fdd.png">

**Case 3**: `mu_r = 9`, Maxwell only
<img width="472" alt="image" src="https://user-images.githubusercontent.com/58234082/97242802-33376380-17cb-11eb-89bf-924dd52a2298.png">
<img width="486" alt="image" src="https://user-images.githubusercontent.com/58234082/97242820-3c283500-17cb-11eb-93d5-809efc0a0ebb.png">

Plot **Case 2** and **Case 3** together:

Maxwell only
<img width="486" alt="image" src="https://user-images.githubusercontent.com/58234082/97242820-3c283500-17cb-11eb-93d5-809efc0a0ebb.png">
LLG+Maxwell
<img width="488" alt="image" src="https://user-images.githubusercontent.com/58234082/97242176-8a3c3900-17c9-11eb-8f40-cc005b9c0e36.png">

Maxwell only
<img width="472" alt="image" src="https://user-images.githubusercontent.com/58234082/97242802-33376380-17cb-11eb-89bf-924dd52a2298.png">
LLG+Maxwell
<img width="477" alt="image" src="https://user-images.githubusercontent.com/58234082/97242183-91634700-17c9-11eb-9c33-79ac639366b9.png">


Input file for LLG+Maxwell case:
```
####################################################################################################
## This input file is a convergence test for a coupled Maxwell+LLG system                         ##
####################################################################################################

################################
####### GENERAL PARAMETERS ######
#################################
max_step = 6000
amr.n_cell = 64 64 64 # number of cells spanning the domain in each coordinate direction at level 0
amr.max_grid_size = 32 # maximum size of each AMReX box, used to decompose the domain
amr.blocking_factor = 16
geometry.coord_sys = 0
geometry.is_periodic = 1 1 1

geometry.prob_lo = -15e-3 -15e-3 -15.0e-3
geometry.prob_hi =  15e-3  15e-3  15.0e-3

amr.max_level = 0

my_constants.pi = 3.14159265359
my_constants.h = 1.0e-3 # thickness of the film
my_constants.c = 299792458.
my_constants.wavelength = 0.2308 # frequency is 1.30 GHz
my_constants.TP = 1.5385e-9 # Gaussian pulse width
my_constants.flag_none = 0
my_constants.flag_hs = 1
my_constants.flag_ss = 2

#################################
############ NUMERICS ###########
#################################
warpx.verbose = 0
warpx.use_filter = 0
warpx.cfl = 0.9
warpx.do_pml = 0
warpx.mag_time_scheme_order = 2 # default 1
warpx.mag_M_normalization = 1 # 1 is saturated
warpx.mag_LLG_coupling = 1
particles.nspecies = 0

algo.em_solver_medium = macroscopic # vacuum/macroscopic
algo.macroscopic_sigma_method = laxwendroff # laxwendroff or backwardeuler

macroscopic.sigma_init_style = "parse_sigma_function" # parse or "constant"
macroscopic.sigma_function(x,y,z) = "0.0"
macroscopic.epsilon_init_style = "parse_epsilon_function" # parse or "constant"
macroscopic.epsilon_function(x,y,z) = "8.8541878128e-12"
macroscopic.mu_init_style = "parse_mu_function" # parse or "constant"
macroscopic.mu_function(x,y,z) = "1.25663706212e-06"

#unit conversion: 1 Gauss = (1000/4pi) A/m
macroscopic.mag_Ms_init_style = "parse_mag_Ms_function" # parse or "constant"
macroscopic.mag_Ms_function(x,y,z) = "0" # in unit A/m, equal to 1750 Gauss; Ms must be nonzero for LLG
macroscopic.mag_alpha_init_style = "parse_mag_alpha_function" # parse or "constant"
macroscopic.mag_alpha_function(x,y,z) = "0.0058" # alpha is unitless, calculated from linewidth Delta_H = 40 Oersted
macroscopic.mag_gamma_init_style = "parse_mag_gamma_function" # parse or "constant"
macroscopic.mag_gamma_function(x,y,z) = "-1.759e11" # gyromagnetic ratio is constant for electrons in all materials

macroscopic.mag_max_iter = 100 # maximum number of M iteration in each time step
macroscopic.mag_tol = 1.e-6 # M magnitude relative error tolerance compared to previous iteration
macroscopic.mag_normalized_error = 0.1 # if M magnitude relatively changes more than this value, raise a red flag

#################################
############ FIELDS #############
#################################
warpx.E_ext_grid_init_style = parse_E_ext_grid_function
warpx.Ex_external_grid_function(x,y,z) = 0.
warpx.Ey_external_grid_function(x,y,z) = 0.
warpx.Ez_external_grid_function(x,y,z) = 0.

warpx.E_excitation_on_grid_style = "parse_E_excitation_grid_function"
warpx.Ex_excitation_grid_function(x,y,z,t) = "0.0"
warpx.Ey_excitation_grid_function(x,y,z,t) = "1000*(exp(-(t-3*TP)**2/(2*TP**2))*cos(2*pi*c/wavelength*t)) * (z>=h) * (z<h+6.0e-4)"
warpx.Ez_excitation_grid_function(x,y,z,t) = "0.0"
warpx.Ex_excitation_flag_function(x,y,z) = "flag_none"
warpx.Ey_excitation_flag_function(x,y,z) = "flag_hs * (z>=h) * (z<h+6.0e-4) + flag_none * (z<h) * (z>=h+6.0e-4)"
warpx.Ez_excitation_flag_function(x,y,z) = "flag_none"

warpx.H_ext_grid_init_style = parse_H_ext_grid_function
warpx.Hx_external_grid_function(x,y,z)= 0.
warpx.Hy_external_grid_function(x,y,z) = 0.
warpx.Hz_external_grid_function(x,y,z) = 0.

#unit conversion: 1 Gauss = 1 Oersted = (1000/4pi) A/m
#calculation of H_bias: H_bias (oe) = frequency / 2.8e6
warpx.H_bias_ext_grid_init_style = parse_H_bias_ext_grid_function
warpx.Hx_bias_external_grid_function(x,y,z)= 0.
warpx.Hy_bias_external_grid_function(x,y,z)= "3.7e4" # in A/m, equal to 464 Oersted
warpx.Hz_bias_external_grid_function(x,y,z)= 0.

warpx.M_ext_grid_init_style = parse_M_ext_grid_function
warpx.Mx_external_grid_function(x,y,z)= 0.
warpx.My_external_grid_function(x,y,z)= "0."
warpx.Mz_external_grid_function(x,y,z) = 0.

#Diagnostics
diagnostics.diags_names = plt
plt.period = 10
plt.diag_type = Full
#plt.fields_to_plot = Ex Ey Ez Bx By Bz
plt.fields_to_plot = Ex Ey Ez Hx Hy Hz Bx By Bz Mx_xface My_xface Mz_xface Mx_yface My_yface Mz_yface Mx_zface My_zface Mz_zface
plt.plot_raw_fields = 0
```


Input file for Maxwell only case:

```
####################################################################################################
## This input file is a convergence test for a coupled Maxwell+LLG system                         ##
####################################################################################################

################################
####### GENERAL PARAMETERS ######
#################################
max_step = 6000
amr.n_cell = 64 64 64 # number of cells spanning the domain in each coordinate direction at level 0
amr.max_grid_size = 32 # maximum size of each AMReX box, used to decompose the domain
amr.blocking_factor = 16
geometry.coord_sys = 0
geometry.is_periodic = 1 1 1

geometry.prob_lo = -15e-3 -15e-3 -15.0e-3
geometry.prob_hi =  15e-3  15e-3  15.0e-3

amr.max_level = 0

my_constants.pi = 3.14159265359
my_constants.h = 1.0e-3 # thickness of the film
my_constants.c = 299792458.
my_constants.wavelength = 0.2308 # frequency is 1.30 GHz
my_constants.TP = 1.5385e-9 # Gaussian pulse width
my_constants.flag_none = 0
my_constants.flag_hs = 1
my_constants.flag_ss = 2

#################################
############ NUMERICS ###########
#################################
warpx.verbose = 0
warpx.use_filter = 0
warpx.cfl = 0.9
warpx.do_pml = 0
#warpx.mag_time_scheme_order = 2 # default 1
#warpx.mag_M_normalization = 1 # 1 is saturated
#warpx.mag_LLG_coupling = 1
particles.nspecies = 0

algo.em_solver_medium = macroscopic # vacuum/macroscopic
algo.macroscopic_sigma_method = laxwendroff # laxwendroff or backwardeuler

macroscopic.sigma_init_style = "parse_sigma_function" # parse or "constant"
macroscopic.sigma_function(x,y,z) = "0.0"
macroscopic.epsilon_init_style = "parse_epsilon_function" # parse or "constant"
macroscopic.epsilon_function(x,y,z) = "8.8541878128e-12"
macroscopic.mu_init_style = "parse_mu_function" # parse or "constant"
macroscopic.mu_function(x,y,z) = "1.1310e-05"

#unit conversion: 1 Gauss = (1000/4pi) A/m
#macroscopic.mag_Ms_init_style = "parse_mag_Ms_function" # parse or "constant"
#macroscopic.mag_Ms_function(x,y,z) = "0" # in unit A/m, equal to 1750 Gauss; Ms must be nonzero for LLG
#macroscopic.mag_alpha_init_style = "parse_mag_alpha_function" # parse or "constant"
#macroscopic.mag_alpha_function(x,y,z) = "0.0058" # alpha is unitless, calculated from linewidth Delta_H = 40 Oersted
#macroscopic.mag_gamma_init_style = "parse_mag_gamma_function" # parse or "constant"
#macroscopic.mag_gamma_function(x,y,z) = "-1.759e11" # gyromagnetic ratio is constant for electrons in all materials

#macroscopic.mag_max_iter = 100 # maximum number of M iteration in each time step
#macroscopic.mag_tol = 1.e-6 # M magnitude relative error tolerance compared to previous iteration
#macroscopic.mag_normalized_error = 0.1 # if M magnitude relatively changes more than this value, raise a red flag

#################################
############ FIELDS #############
#################################
warpx.E_ext_grid_init_style = parse_E_ext_grid_function
warpx.Ex_external_grid_function(x,y,z) = 0.
warpx.Ey_external_grid_function(x,y,z) = 0.
warpx.Ez_external_grid_function(x,y,z) = 0.

warpx.E_excitation_on_grid_style = "parse_E_excitation_grid_function"
warpx.Ex_excitation_grid_function(x,y,z,t) = "0.0"
warpx.Ey_excitation_grid_function(x,y,z,t) = "1000*(exp(-(t-3*TP)**2/(2*TP**2))*cos(2*pi*c/wavelength*t)) * (z>=h) * (z<h+6.0e-4)"
warpx.Ez_excitation_grid_function(x,y,z,t) = "0.0"
warpx.Ex_excitation_flag_function(x,y,z) = "flag_none"
warpx.Ey_excitation_flag_function(x,y,z) = "flag_hs * (z>=h) * (z<h+6.0e-4) + flag_none * (z<h) * (z>=h+6.0e-4)"
warpx.Ez_excitation_flag_function(x,y,z) = "flag_none"

warpx.B_ext_grid_init_style = parse_B_ext_grid_function
warpx.Bx_external_grid_function(x,y,z)= "0.0"
warpx.By_external_grid_function(x,y,z)= 0.
warpx.Bz_external_grid_function(x,y,z) = 0.

#warpx.H_ext_grid_init_style = parse_H_ext_grid_function
#warpx.Hx_external_grid_function(x,y,z)= 0.
#warpx.Hy_external_grid_function(x,y,z) = 0.
#warpx.Hz_external_grid_function(x,y,z) = 0.

#unit conversion: 1 Gauss = 1 Oersted = (1000/4pi) A/m
#calculation of H_bias: H_bias (oe) = frequency / 2.8e6
#warpx.H_bias_ext_grid_init_style = parse_H_bias_ext_grid_function
#warpx.Hx_bias_external_grid_function(x,y,z)= 0.
#warpx.Hy_bias_external_grid_function(x,y,z)= "3.7e4" # in A/m, equal to 464 Oersted
#warpx.Hz_bias_external_grid_function(x,y,z)= 0.

#warpx.M_ext_grid_init_style = parse_M_ext_grid_function
#warpx.Mx_external_grid_function(x,y,z)= 0.
#warpx.My_external_grid_function(x,y,z)= "0."
#warpx.Mz_external_grid_function(x,y,z) = 0.

#Diagnostics
diagnostics.diags_names = plt
plt.period = 10
plt.diag_type = Full
plt.fields_to_plot = Ex Ey Ez Bx By Bz
#plt.fields_to_plot = Ex Ey Ez Hx Hy Hz Bx By Bz Mx_xface My_xface Mz_xface Mx_yface My_yface Mz_yface Mx_zface My_zface Mz_zface
plt.plot_raw_fields = 0

```
